### PR TITLE
Re-introduce sudo for read-only scripts

### DIFF
--- a/helpers/shells/getLastSave.sh
+++ b/helpers/shells/getLastSave.sh
@@ -22,4 +22,4 @@
 # Exit when any command fails
 set -e
 
-stat -c {\"user\":\"%U\",\"lastSave\":%Y\} /var/borgwarehouse/*/repos/*/integrity* | jq -s
+sudo stat -c {\"user\":\"%U\",\"lastSave\":%Y\} /var/borgwarehouse/*/repos/*/integrity* | jq -s

--- a/helpers/shells/getStorageUsed.sh
+++ b/helpers/shells/getStorageUsed.sh
@@ -16,4 +16,4 @@ set -e
 
 # Use jc to output a JSON format with du command
 cd /var/borgwarehouse
-jc du -s *
+sudo jc du -s *


### PR DESCRIPTION
This reintroduces the sudo commands for the read-only operations in the getLastSave.sh and getStorageUsed.sh scripts.

This fixes the v1.0 branch for now together with these sudoers rules:

```
borgwarehouse ALL=(ALL) NOPASSWD: /usr/bin/jc du -s [[\:xdigit\:]]*
borgwarehouse ALL=(ALL) NOPASSWD: /usr/bin/stat -c {"user"\:"%U"\,"lastSave"\:%Y} /var/borgwarehouse/[[\:xdigit\:]]*/repos/repo[[\:digit\:]]*/integrity.[[\:digit\:]]*
```