### PR TITLE
fix typo in wizard step 4

### DIFF
--- a/Components/WizardSteps/WizardStep4/WizardStep4.js
+++ b/Components/WizardSteps/WizardStep4/WizardStep4.js
@@ -46,7 +46,7 @@ consistency:
     checks:
         - name: repository
         - name: archives
-        - frequency: 2 weeks
+          frequency: 2 weeks
 
 #hooks:
     # Custom preparation scripts to run.


### PR DESCRIPTION
There is a typo in wizard step 4. This fixes it. 

Also, with borgmatic 1.8.2 at least, storage and location is about to be deprecated so I removed them in my configs :)