### PR TITLE
Rework Dockerfile to reduce image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,11 @@
 node_modules
 .git
 .gitignore  
+.dockerignore
 .pre-commit-config.yaml
 .prettierrc.json
 .env.local
 .next
+Dockerfile
+docker-compose.yml
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,33 @@
-FROM node:18-bookworm-slim
+FROM node:18-bookworm-slim as base
+
+# build stage
+FROM base AS deps
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+
+RUN npm ci --only=production
+
+FROM base AS builder
+
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+
+COPY . .
+
+RUN sed -i "s/images:/output: 'standalone',images:/" next.config.js
+
+RUN npm run build
+
+# run stage
+FROM base AS runner
+
+ENV NODE_ENV production
 
 RUN apt-get update && apt-get install -y \
-    curl git jq jc borgbackup openssh-server sudo cron && \
-    apt-get upgrade -y && \
+    curl jq jc borgbackup openssh-server sudo cron && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN echo "borgwarehouse ALL=(ALL) NOPASSWD: /usr/sbin/service ssh restart" >> /etc/sudoers
@@ -17,18 +42,16 @@ RUN cp /etc/ssh/sshd_config /etc/ssh/moduli /home/borgwarehouse/
 
 WORKDIR /home/borgwarehouse/app
 
-COPY . .
-
-RUN chown -R borgwarehouse:borgwarehouse * .*
+COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/docker-bw-init.sh /app/LICENSE ./
+COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/helpers/shells ./helpers/shells
+COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/.next/standalone ./
+COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/public ./public
+COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/.next/static ./.next/static
 
 USER borgwarehouse
-
-RUN npm ci --only=production
-
-RUN npm run build
 
 EXPOSE 3000 22
 
 ENTRYPOINT ["./docker-bw-init.sh"]
 
-CMD ["npm", "run", "start"]
+CMD ["node", "server.js"]


### PR DESCRIPTION
Things that changed:
- split the build process into two stages (added a separate build stage)
- build the app in [standalone mode](https://nextjs.org/docs/pages/api-reference/next-config-js/output#automatically-copying-traced-files). Based on [this example](https://nextjs.org/docs/app/building-your-application/deploying#docker-image)
- switched to using `--chown=borgwarehouse:borgwarehouse` to avoid an unmercenary copy that comes with a manual chown.
- removed the `git` apt package (I wasn't able to find where it's used so I'm assuming it's not needed)
- removed the `apt upgrade` command. IMO this should be done by just pulling a new version of the base image and rebuilding.
- added extra files to `.dockerignore` to help with caching builds

I decided against trying to move away from the Debian base, so that's actually unchanged. Maybe I will make a separate alpine-based image later.

closes #57 