### PR TITLE
Use environmental variables for docker-compose

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,22 @@
+# ports
+WEB_SERVER_PORT=3000
+SSH_SERVER_PORT=2222
+
+# your domain
+FQDN=your.domain.com
+NEXTAUTH_URL=https://your.domain.com
+
+# secrets
+NEXTAUTH_SECRET=your-secret
+CRONJOB_KEY=your-other-secret
+
+# UID:GID must match the user and group ID of the host folders and must be > 1000
+UID=1001
+GID=1001
+
+# config folders
+# The host folders must be owned by the user with UID and GID specified above
+CONFIG_PATH=./config
+SSH_PATH=./ssh
+SSH_HOST=./ssh_host
+BORG_REPOSITORY_PATH=./repos

--- a/.env.sample
+++ b/.env.sample
@@ -1,12 +1,14 @@
-# ports
+## Required variables section ##
+
+# Host port mappings
 WEB_SERVER_PORT=3000
 SSH_SERVER_PORT=2222
 
-# your domain
+# Hostname and URL
 FQDN=your.domain.com
 NEXTAUTH_URL=https://your.domain.com
 
-# secrets
+# Secrects
 NEXTAUTH_SECRET=your-secret
 CRONJOB_KEY=your-other-secret
 
@@ -14,9 +16,23 @@ CRONJOB_KEY=your-other-secret
 UID=1001
 GID=1001
 
-# config folders
+# Config and data folders (volume mounts)
 # The host folders must be owned by the user with UID and GID specified above
 CONFIG_PATH=./config
 SSH_PATH=./ssh
 SSH_HOST=./ssh_host
 BORG_REPOSITORY_PATH=./repos
+
+## Optional variables section ##
+
+# LAN feature
+FQDN_LAN=
+SSH_SERVER_PORT_LAN=
+
+# SMTP server settings
+MAIL_SMTP_FROM=
+MAIL_SMTP_HOST=
+MAIL_SMTP_PORT=
+MAIL_SMTP_LOGIN=
+MAIL_SMTP_PWD=
+MAIL_REJECT_SELFSIGNED_TLS=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,24 +7,22 @@ services:
         #   context: .
         #   dockerfile: Dockerfile
         image: borgwarehouse/borgwarehouse
-        # UID:GID must match the user and group ID of the host folders and must be > 1000
-        user: '1001:1001'
+        user: "${UID:?UID variable missing}:${GID:?GID variable missing}"
         ports:
-            - '3000:3000'
-            - '2222:22'
+            - "${WEB_SERVER_PORT:?WEB_SERVER_PORT variable missing}:3000"
+            - "${SSH_SERVER_PORT:?SSH_SERVER_PORT variable missing}:22"
         environment:
-            - NEXTAUTH_URL=https://your.domain.com
-            - NEXTAUTH_SECRET=your-secret
-            - CRONJOB_KEY=your-other-secret
-            # The SSH_SERVER_PORT must match the port exposed above
-            - SSH_SERVER_PORT=2222
-            - FQDN=your.domain.com
+            - NEXTAUTH_URL=${NEXTAUTH_URL:?NEXTAUTH_URL variable missing}
+            - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:?NEXTAUTH_SECRET variable missing}
+            - CRONJOB_KEY=${CRONJOB_KEY:?CRONJOB_KEY variable missing}
+            - SSH_SERVER_PORT=${SSH_SERVER_PORT:?SSH_SERVER_PORT variable missing}
+            - FQDN=${FQDN:?FQDN variable missing}
         volumes:
-            # The host folders must be owned by the user with UID and GID specified above
-            - <host-folder>/config:/home/borgwarehouse/app/config
-            - <host-folder>/ssh:/home/borgwarehouse/.ssh
-            - <host-folder>/ssh_host:/etc/ssh
-            - <host-folder>/repos:/home/borgwarehouse/repos
+            - ${CONFIG_PATH:?CONFIG_PATH variable missing}:/home/borgwarehouse/app/config
+            - ${SSH_PATH:?SSH_PATH variable missing}:/home/borgwarehouse/.ssh
+            - ${SSH_HOST:?SSH_HOST variable missing}:/etc/ssh
+            - ${BORG_REPOSITORY_PATH:?BORG_REPOSITORY_PATH variable missing}:/home/borgwarehouse/repos
+    
     # Apprise is used to send notifications, it's optional. http://apprise:8000 is the URL to use in BorgWarehouse.
     apprise:
         container_name: apprise

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,8 @@ services:
         ports:
             - "${WEB_SERVER_PORT:?WEB_SERVER_PORT variable missing}:3000"
             - "${SSH_SERVER_PORT:?SSH_SERVER_PORT variable missing}:22"
-        environment:
-            - NEXTAUTH_URL=${NEXTAUTH_URL:?NEXTAUTH_URL variable missing}
-            - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:?NEXTAUTH_SECRET variable missing}
-            - CRONJOB_KEY=${CRONJOB_KEY:?CRONJOB_KEY variable missing}
-            - SSH_SERVER_PORT=${SSH_SERVER_PORT:?SSH_SERVER_PORT variable missing}
-            - FQDN=${FQDN:?FQDN variable missing}
+        env_file:
+            - .env
         volumes:
             - ${CONFIG_PATH:?CONFIG_PATH variable missing}:/home/borgwarehouse/app/config
             - ${SSH_PATH:?SSH_PATH variable missing}:/home/borgwarehouse/.ssh


### PR DESCRIPTION
* You can start it as usual, `.env` file is automatically used.
* IMHO easier and cleaner to configure.
* Also removed the `<host>` as it makes this not-runnable out-of-the-box. I need this for https://github.com/Ravinou/borgwarehouse/pull/69 and this was the initial idea of making this PR.
* The `${:?}` syntax is a bash-like thing to produce a proper error message if the variable is not provided.

I checked the setup should basically start (just got a permission error as the UID/GID is wrong).