### PR TITLE
fix: disable cronjob functionnality in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,10 @@ FROM base AS runner
 ENV NODE_ENV production
 
 RUN apt-get update && apt-get install -y \
-    curl jq jc borgbackup openssh-server sudo cron && \
+    curl jq jc borgbackup openssh-server sudo && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN echo "borgwarehouse ALL=(ALL) NOPASSWD: /usr/sbin/service ssh restart" >> /etc/sudoers
-
-RUN echo "borgwarehouse ALL=(ALL) NOPASSWD: /usr/sbin/service cron restart" >> /etc/sudoers
 
 RUN groupadd borgwarehouse
 

--- a/docker-bw-init.sh
+++ b/docker-bw-init.sh
@@ -47,12 +47,6 @@ check_repos_directory() {
   fi
 }
 
-add_cron_job() {
-  print_green "Adding cron job..."
-  local CRON_JOB="* * * * * curl --request POST --url 'http://$HOSTNAME:3000/api/cronjob/checkStatus' --header 'Authorization: Bearer $CRONJOB_KEY'; curl --request POST --url 'http://$HOSTNAME:3000/api/cronjob/getStorageUsed' --header 'Authorization: Bearer $CRONJOB_KEY'"
-  echo "$CRON_JOB" | crontab -u borgwarehouse -
-}
-
 get_SSH_fingerprints() {
   print_green "Getting SSH fingerprints..."
   RSA_FINGERPRINT=$(ssh-keygen -lf /etc/ssh/ssh_host_rsa_key | awk '{print $2}')
@@ -82,10 +76,8 @@ init_ssh_server
 check_ssh_directory
 create_authorized_keys_file
 check_repos_directory
-add_cron_job
 get_SSH_fingerprints
 
 sudo service ssh restart
-sudo service cron restart
 
 exec "$@"


### PR DESCRIPTION
Having a cron in a docker container is not good practice. Like all docker software, BorgWarehouse provides an endpoint that you can call with the scheduler of your choice. The docker documentation will be updated accordingly.

Cron deletion will certainly be linked to the #98 ... testing in next days.