### PR TITLE
Speedup docker builds

### DIFF
--- a/.github/workflows/docker-image-develop.yml
+++ b/.github/workflows/docker-image-develop.yml
@@ -1,0 +1,29 @@
+name: Build and Push Docker Image for Develop Branch
+
+on:
+    push:
+        branches:
+            - 'develop'
+
+jobs:
+    docker:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+            - name: Login to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+            - name: Build and push
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  push: true
+                  platforms: linux/amd64,linux/arm64,linux/arm
+                  tags: borgwarehouse/borgwarehouse:develop

--- a/.github/workflows/docker-image-develop.yml
+++ b/.github/workflows/docker-image-develop.yml
@@ -25,5 +25,5 @@ jobs:
               with:
                   context: .
                   push: true
-                  platforms: linux/amd64,linux/arm64,linux/arm
+                  platforms: linux/amd64,linux/arm64,linux/arm/v7
                   tags: borgwarehouse/borgwarehouse:develop

--- a/.github/workflows/docker-image-develop.yml
+++ b/.github/workflows/docker-image-develop.yml
@@ -5,6 +5,10 @@ on:
         branches:
             - 'develop'
 
+# allow forks to override the dockerhub namespace with one of their own
+env:
+    DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE || 'borgwarehouse' }}
+
 jobs:
     docker:
         runs-on: ubuntu-latest
@@ -25,5 +29,5 @@ jobs:
               with:
                   context: .
                   push: true
-                  platforms: linux/amd64,linux/arm64,linux/arm/v7
-                  tags: borgwarehouse/borgwarehouse:develop
+                  platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+                  tags: ${{ env.DOCKERHUB_NAMESPACE }}/borgwarehouse:develop

--- a/.github/workflows/docker-image-latest.yml
+++ b/.github/workflows/docker-image-latest.yml
@@ -1,34 +1,29 @@
 name: Build and Push Docker Image
 
 on:
-  push:
-    branches:
-      - 'main'
+    push:
+        branches:
+            - 'main'
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64,linux/arm
-          tags: borgwarehouse/borgwarehouse:latest
+    docker:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+            - name: Login to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+            - name: Build and push
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  push: true
+                  platforms: linux/amd64,linux/arm64,linux/arm/v7
+                  tags: borgwarehouse/borgwarehouse:latest

--- a/.github/workflows/docker-image-latest.yml
+++ b/.github/workflows/docker-image-latest.yml
@@ -5,6 +5,10 @@ on:
         branches:
             - 'main'
 
+# allow forks to override the dockerhub namespace with one of their own
+env:
+    DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE || 'borgwarehouse' }}
+
 jobs:
     docker:
         runs-on: ubuntu-latest
@@ -25,5 +29,5 @@ jobs:
               with:
                   context: .
                   push: true
-                  platforms: linux/amd64,linux/arm64,linux/arm/v7
-                  tags: borgwarehouse/borgwarehouse:latest
+                  platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+                  tags: ${{ env.DOCKERHUB_NAMESPACE }}/borgwarehouse:latest

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -28,5 +28,5 @@ jobs:
               with:
                   context: .
                   push: true
-                  platforms: linux/amd64,linux/arm64,linux/arm/v7
+                  platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
                   tags: borgwarehouse/borgwarehouse:${{ steps.get_release_tag.outputs.TAG }}

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -1,38 +1,32 @@
 name: Build and Push Docker Image on Release
 
 on:
-  release:
-    types:
-      - published
+    release:
+        types:
+            - published
 
 jobs:
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Get Release Tag
-        id: get_release_tag
-        run: echo "::set-output name=TAG::${{ github.event.release.tag_name }}"
-      -
-        name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: borgwarehouse/borgwarehouse:${{ steps.get_release_tag.outputs.TAG }}
+    docker:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+            - name: Login to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+            - name: Get Release Tag
+              id: get_release_tag
+              run: echo "::set-output name=TAG::${{ github.event.release.tag_name }}"
+            - name: Build and push
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  push: true
+                  platforms: linux/amd64,linux/arm64,linux/arm/v7
+                  tags: borgwarehouse/borgwarehouse:${{ steps.get_release_tag.outputs.TAG }}

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -8,6 +8,13 @@ on:
 jobs:
     build-container:
         runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                platform:
+                    - linux/amd64
+                    - linux/arm/v7
+                    - linux/arm64/v8
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -16,5 +23,9 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v3
             - name: Build Docker Container
-              run: |
-                  docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t borgwarehouse:pr-${{ github.event.pull_request.number }} .
+              uses: docker/build-push-action@v5
+              with:
+                  context: .
+                  push: false
+                  platforms: ${{ matrix.platform }}
+                  tags: borgwarehouse:pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -8,13 +8,6 @@ on:
 jobs:
     build-container:
         runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                platform:
-                    - linux/amd64
-                    - linux/arm/v7
-                    - linux/arm64/v8
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -27,5 +20,5 @@ jobs:
               with:
                   context: .
                   push: false
-                  platforms: ${{ matrix.platform }}
+                  platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
                   tags: borgwarehouse:pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -1,24 +1,20 @@
 name: Test Docker Container Build on Pull Request
 
 on:
-  pull_request:
-    branches:
-      - main
+    pull_request:
+        branches:
+            - main
 
 jobs:
-  build-container:
-    runs-on: ubuntu-latest
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Build Docker Container
-        run: |
-          docker buildx build --platform linux/amd64,linux/arm64 -t borgwarehouse:pr-${{ github.event.pull_request.number }} .
+    build-container:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+            - name: Build Docker Container
+              run: |
+                  docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t borgwarehouse:pr-${{ github.event.pull_request.number }} .

--- a/Components/Repo/QuickCommands/QuickCommands.js
+++ b/Components/Repo/QuickCommands/QuickCommands.js
@@ -50,11 +50,13 @@ export default function QuickCommands(props) {
                 <div className={classes.copyValid}>Copied !</div>
             ) : (
                 <div className={classes.tooltip}>
-                    ssh://{wizardEnv.UNIX_USER}@
-                    {FQDN}:{SSH_SERVER_PORT}/./
+                    ssh://{wizardEnv.UNIX_USER}@{FQDN}:{SSH_SERVER_PORT}/./
                     {props.repositoryName}
                 </div>
             )}
+
+            {props.lanCommand && <div className={classes.lanBadge}>LAN</div>}
+
             <div className={classes.icons}>
                 <button onClick={handleCopy} className={classes.copyButton}>
                     <IconCopy color='#65748b' stroke={1.25} />

--- a/Components/Repo/QuickCommands/QuickCommands.module.css
+++ b/Components/Repo/QuickCommands/QuickCommands.module.css
@@ -7,13 +7,22 @@
 
 .icons {
     position: relative;
-    bottom: 14px;
+    bottom: 13px;
 }
 
 .quickSetting {
     position: absolute;
     visibility: visible;
     opacity: 1;
+}
+
+.lanBadge {
+    border-radius: 5px;
+    border: 1px solid #6d4aff;
+    color: #6d4aff;
+    font-size: 0.9em;
+    padding: 2px 5px;
+    margin-right: 8px;
 }
 
 .tooltip {
@@ -89,6 +98,15 @@
     position: absolute;
     visibility: hidden;
     opacity: 0;
+}
+
+.container:hover .lanBadge {
+    visibility: hidden;
+    opacity: 0;
+    width: 0;
+    height: 0;
+    margin: 0;
+    padding: 0;
 }
 
 @media all and (max-width: 1000px) {

--- a/Components/Repo/Repo.js
+++ b/Components/Repo/Repo.js
@@ -6,6 +6,7 @@ import {
     IconInfoCircle,
     IconChevronDown,
     IconChevronUp,
+    IconBellOff,
 } from '@tabler/icons-react';
 import timestampConverter from '../../helpers/functions/timestampConverter';
 import StorageBar from '../UI/StorageBar/StorageBar';
@@ -53,22 +54,33 @@ export default function Repo(props) {
         setDisplayDetails(boolean);
     };
 
+    //Status indicator
+    const statusIndicator = () => {
+        return props.status
+            ? classes.statusIndicatorGreen
+            : classes.statusIndicatorRed;
+    };
+
+    //Alert indicator
+    const alertIndicator = () => {
+        if (props.alert === 0) {
+            return (
+                <div className={classes.alertIcon}>
+                    <IconBellOff size={16} color='grey' />
+                </div>
+            );
+        }
+    };
+
     return (
         <>
             {displayDetails ? (
                 <>
                     <div className={classes.RepoOpen}>
                         <div className={classes.openFlex}>
-                            {props.status ? (
-                                <div
-                                    className={classes.statusIndicatorGreen}
-                                ></div>
-                            ) : (
-                                <div
-                                    className={classes.statusIndicatorRed}
-                                ></div>
-                            )}
+                            <div className={statusIndicator()} />
                             <div className={classes.alias}>{props.alias}</div>
+                            {alertIndicator()}
                             {props.comment && (
                                 <div className={classes.comment}>
                                     <IconInfoCircle size={16} color='grey' />
@@ -141,16 +153,9 @@ export default function Repo(props) {
                 <>
                     <div className={classes.RepoClose}>
                         <div className={classes.closeFlex}>
-                            {props.status ? (
-                                <div
-                                    className={classes.statusIndicatorGreen}
-                                ></div>
-                            ) : (
-                                <div
-                                    className={classes.statusIndicatorRed}
-                                ></div>
-                            )}
+                            <div className={statusIndicator()} />
                             <div className={classes.alias}>{props.alias}</div>
+                            {alertIndicator()}
                             {props.comment && (
                                 <div className={classes.comment}>
                                     <IconInfoCircle size={16} color='#637381' />

--- a/Components/Repo/Repo.module.css
+++ b/Components/Repo/Repo.module.css
@@ -148,6 +148,15 @@
     }
 }
 
+/* Alert icon */
+
+.alertIcon {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-left: 10px;
+}
+
 /* GENERAL */
 .alias {
     font-weight: bold;

--- a/Containers/RepoList/RepoList.js
+++ b/Containers/RepoList/RepoList.js
@@ -116,6 +116,7 @@ export default function RepoList() {
                     alias={repo.alias}
                     status={repo.status}
                     lastSave={repo.lastSave}
+                    alert={repo.alert}
                     repositoryName={repo.repositoryName}
                     storageSize={repo.storageSize}
                     storageUsed={repo.storageUsed}

--- a/Containers/RepoManage/RepoManage.js
+++ b/Containers/RepoManage/RepoManage.js
@@ -23,6 +23,7 @@ export default function RepoManage(props) {
     } = useForm({ mode: 'onChange' });
     //List of possible times for alerts
     const alertOptions = [
+        { value: 0, label: 'Disabled' },
         { value: 3600, label: '1 hour' },
         { value: 21600, label: '6 hours' },
         { value: 43200, label: '12 hours' },
@@ -471,7 +472,7 @@ export default function RepoManage(props) {
                                                       x.value ===
                                                       targetRepo.alert
                                               )
-                                            : alertOptions[3]
+                                            : alertOptions[4]
                                     }
                                     control={control}
                                     render={({

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,10 +27,9 @@ FROM base AS runner
 ENV NODE_ENV production
 
 RUN apt-get update && apt-get install -y \
-    curl jq jc borgbackup openssh-server sudo && \
+    supervisor \
+    curl jq jc borgbackup openssh-server sudo cron && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
-
-RUN echo "borgwarehouse ALL=(ALL) NOPASSWD: /usr/sbin/service ssh restart" >> /etc/sudoers
 
 RUN groupadd borgwarehouse
 
@@ -40,16 +39,17 @@ RUN cp /etc/ssh/sshd_config /etc/ssh/moduli /home/borgwarehouse/
 
 WORKDIR /home/borgwarehouse/app
 
-COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/docker-bw-init.sh /app/LICENSE ./
+COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/docker/docker-bw-init.sh /app/LICENSE ./
 COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/helpers/shells ./helpers/shells
 COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/.next/standalone ./
 COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/public ./public
 COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/.next/static ./.next/static
+COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/docker/supervisord.conf ./
 
 USER borgwarehouse
 
 EXPOSE 3000 22
 
-ENTRYPOINT ["./docker-bw-init.sh"]
+ENTRYPOINT ["./docker/docker-bw-init.sh"]
 
 CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,6 @@ USER borgwarehouse
 
 EXPOSE 3000 22
 
-ENTRYPOINT ["./docker/docker-bw-init.sh"]
+ENTRYPOINT ["./docker-bw-init.sh"]
 
 CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,12 +27,10 @@ FROM base AS runner
 ENV NODE_ENV production
 
 RUN apt-get update && apt-get install -y \
-    curl jq jc borgbackup openssh-server sudo cron && \
+    curl jq jc borgbackup openssh-server sudo && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN echo "borgwarehouse ALL=(ALL) NOPASSWD: /usr/sbin/service ssh restart" >> /etc/sudoers
-
-RUN echo "borgwarehouse ALL=(ALL) NOPASSWD: /usr/sbin/service cron restart" >> /etc/sudoers
 
 RUN groupadd borgwarehouse
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ARG RUNASGROUP
 ## Packages installation
 # NOTE: jc isn't available in alpine repos, so we need to install it via pip
 # NOTE2: we pre-install all the available dependencies for jc from the alpine repos to avoid having to build them ourselves
-RUN apk add jq python3 borgbackup openssh-server bash openssl supervisor nss_wrapper gettext rsyslog py3-pip py3-ruamel.yaml py3-xmltodict \
+RUN apk add jq python3 borgbackup openssh-server bash coreutils openssl supervisor nss_wrapper gettext rsyslog py3-pip py3-ruamel.yaml py3-xmltodict \
     && python3 -m pip install --root-user-action=ignore jc \
     && apk del py3-pip \
     && rm -rf /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ARG ADDITIONALPACKAGEARM64
 # Packages installation
 RUN apk add --no-cache jq py3-pip borgbackup openssh-server bash openssl nss_wrapper gettext ${ADDITIONALPACKAGEARM64}
 ## jc installation via pip packages - not alpine package available
-RUN python3 -m pip install jc
+RUN python3 -m pip install jc supervisor supervisord-dependent-startup
 
 ENV NODE_ENV production
 
@@ -68,4 +68,4 @@ EXPOSE 2222 3000
 
 ENTRYPOINT ["/entrypoint.sh"]
 
-CMD ["node", "server.js"]
+CMD ["supervisord","-c", "/etc_ssh/etc/ssh/supervisord.conf"]

--- a/docker-bw-init.sh
+++ b/docker-bw-init.sh
@@ -47,12 +47,6 @@ check_repos_directory() {
   fi
 }
 
-add_cron_job() {
-  print_green "Adding cron job..."
-  local CRON_JOB="* * * * * curl --request POST --url 'http://$HOSTNAME:3000/api/cronjob/checkStatus' --header 'Authorization: Bearer $CRONJOB_KEY'; curl --request POST --url 'http://$HOSTNAME:3000/api/cronjob/getStorageUsed' --header 'Authorization: Bearer $CRONJOB_KEY'"
-  echo "$CRON_JOB" | crontab -u borgwarehouse -
-}
-
 get_SSH_fingerprints() {
   print_green "Getting SSH fingerprints..."
   RSA_FINGERPRINT=$(ssh-keygen -lf /etc/ssh/ssh_host_rsa_key | awk '{print $2}')
@@ -82,10 +76,8 @@ init_ssh_server
 check_ssh_directory
 create_authorized_keys_file
 check_repos_directory
-add_cron_job
 get_SSH_fingerprints
 
 sudo service ssh restart
-sudo service cron restart
 
 exec "$@"

--- a/docker-resources/entrypoint.sh
+++ b/docker-resources/entrypoint.sh
@@ -4,7 +4,6 @@ set -e
 # Dockerfile values
 dockerfileUser="borgwarehouse"
 dockerfileUserid="1001"
-dockerfileVolume="/etc_ssh"
 
 # mapping uid/gid process owner to borgwarehouse user with nss_wrapper
 #echo "Current user is $(id -u)"
@@ -14,10 +13,10 @@ export user_id group_id
 
 origpasswd="/etc/passwd"
 origgroup="/etc/group"
-# As this container is runable in read-only mode, the new passwd file must be written in one mounted volume
-# /etc_ssh/etc/ssh/ is volume in this case
-newpasswd="$dockerfileVolume/etc/ssh/passwd"
-newgroup="$dockerfileVolume/etc/ssh/group"
+# As this container is runable in read-only mode, the new passwd file must be written
+# within a mounted volume /tmp is also needed by supervisord
+newpasswd="/tmp/passwd"
+newgroup="/tmp/group"
 
 # except if process owner is 1001
 if [ "$(id -u)" != "$dockerfileUserid" ]; then
@@ -33,12 +32,18 @@ if [ "$(id -u)" != "$dockerfileUserid" ]; then
 fi
 
 # Generate ssh keys if not exist - is empty ?
-if [ ! "$(ls -A "$dockerfileVolume/etc/ssh")" ]; then
-  ssh-keygen -A -f $dockerfileVolume
+if [ ! "$(ls -A "/etc/ssh")" ]; then
+  ssh-keygen -A -f /etc/ssh
 fi
+
 # Install sshd_config
-if [ ! -f "$dockerfileVolume/etc/ssh/sshd_config" ]; then
-  cp /sshd_config.conf $dockerfileVolume/etc/ssh/sshd_config
+if [ ! -f "/etc/ssh/sshd_config" ]; then
+  cp /sshd_config.conf /etc/ssh/sshd_config
 fi
+
+# To avoid this error in log container at start : sync problem
+# rsyslogd: imfile error trying to access state file for '/tmp/sshd.log': Permission denied [v8.2306.0 try https://www.rsyslog.com/e/2027 │
+# rsyslogd: imfile error trying to access state file for '/tmp/borgwarehouse.log': Permission denied [v8.2306.0 try https://www.rsyslog.c
+touch /tmp/sshd.log /tmp/borgwarehouse.log
 
 exec "$@"

--- a/docker-resources/entrypoint.sh
+++ b/docker-resources/entrypoint.sh
@@ -40,7 +40,5 @@ fi
 if [ ! -f "$dockerfileVolume/etc/ssh/sshd_config" ]; then
   cp /sshd_config.conf $dockerfileVolume/etc/ssh/sshd_config
 fi
-# Starting sshd daemon and log to file... change LOGLEVEL in sshd_config
-/usr/sbin/sshd -f $dockerfileVolume/etc/ssh/sshd_config -E $dockerfileVolume/etc/ssh/sshd.log
 
 exec "$@"

--- a/docker-resources/entrypoint.sh
+++ b/docker-resources/entrypoint.sh
@@ -33,7 +33,7 @@ fi
 
 # Generate ssh keys if not exist - is empty ?
 if [ ! "$(ls -A "/etc/ssh")" ]; then
-  ssh-keygen -A -f /etc/ssh
+  ssh-keygen -A
 fi
 
 # Install sshd_config

--- a/docker-resources/entrypoint.sh
+++ b/docker-resources/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+# Dockerfile values
+dockerfileUser="borgwarehouse"
+dockerfileUserid="1001"
+dockerfileVolume="/etc_ssh"
+
+# mapping uid/gid process owner to borgwarehouse user with nss_wrapper
+#echo "Current user is $(id -u)"
+user_id=$(id -u)
+group_id=$(id -g)
+export user_id group_id
+
+origpasswd="/etc/passwd"
+origgroup="/etc/group"
+# As this container is runable in read-only mode, the new passwd file must be written in one mounted volume
+# /etc_ssh/etc/ssh/ is volume in this case
+newpasswd="$dockerfileVolume/etc/ssh/passwd"
+newgroup="$dockerfileVolume/etc/ssh/group"
+
+# except if process owner is 1001
+if [ "$(id -u)" != "$dockerfileUserid" ]; then
+  # map user with borgwarehouse
+  line=$(grep $dockerfileUser ${origpasswd} | awk -F ":" '{print $1":"$2":"ENVIRON["user_id"]":"ENVIRON["group_id"]":"$5":"$6":"$7}')
+  cat ${origpasswd} | sed -E "s|^$dockerfileUser.*$|$line|" >${newpasswd}
+  # map group with $dockerfileUser
+  line=$(grep $dockerfileUser ${origgroup} | awk -F ":" '{print $1":x:"ENVIRON["group_id"]":"}')
+  cat ${origgroup} | sed -E "s|^$dockerfileUser.*$|$line|" >${newgroup}
+  export LD_PRELOAD=/usr/lib/libnss_wrapper.so
+  export NSS_WRAPPER_PASSWD="${newpasswd}"
+  export NSS_WRAPPER_GROUP="${newgroup}"
+fi
+
+# Generate ssh keys if not exist - is empty ?
+if [ ! "$(ls -A "$dockerfileVolume/etc/ssh")" ]; then
+  ssh-keygen -A -f $dockerfileVolume
+fi
+# Install sshd_config
+if [ ! -f "$dockerfileVolume/etc/ssh/sshd_config" ]; then
+  cp /sshd_config.conf $dockerfileVolume/etc/ssh/sshd_config
+fi
+# Starting sshd daemon and log to file... change LOGLEVEL in sshd_config
+/usr/sbin/sshd -f $dockerfileVolume/etc/ssh/sshd_config -E $dockerfileVolume/etc/ssh/sshd.log
+
+exec "$@"

--- a/docker-resources/nss_wrapper_profile.sh
+++ b/docker-resources/nss_wrapper_profile.sh
@@ -2,7 +2,7 @@
 # Only set if user <> 1001 - nss_wrapper for others
 if [ "$UID" != "1001" ]; then
     LD_PRELOAD="/usr/lib/libnss_wrapper.so"
-    NSS_WRAPPER_PASSWD="/etc_ssh/etc/ssh/passwd"
-    NSS_WRAPPER_GROUP="/etc_ssh/etc/ssh/group"
+    NSS_WRAPPER_PASSWD="/tmp/passwd"
+    NSS_WRAPPER_GROUP="/tmp/group"
     export LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
 fi

--- a/docker-resources/nss_wrapper_profile.sh
+++ b/docker-resources/nss_wrapper_profile.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Only set if user <> 1001 - nss_wrapper for others
+if [ "$UID" != "1001" ]; then
+    LD_PRELOAD="/usr/lib/libnss_wrapper.so"
+    NSS_WRAPPER_PASSWD="/etc_ssh/etc/ssh/passwd"
+    NSS_WRAPPER_GROUP="/etc_ssh/etc/ssh/group"
+    export LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+fi

--- a/docker-resources/rsyslog.conf
+++ b/docker-resources/rsyslog.conf
@@ -1,0 +1,44 @@
+# rsyslog configuration file
+#
+# For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
+# or latest version online at http://www.rsyslog.com/doc/rsyslog_conf.html
+# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+
+
+#### Global directives ####
+
+# Sets the directory that rsyslog uses for work files.
+$WorkDirectory /tmp
+
+# Sets default permissions for all log files.
+$FileOwner borgwarehouse
+$FileGroup borgwarehouse
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+
+# Check config syntax on startup and abort if unclean (default off).
+#$AbortOnUncleanConfig on
+
+# Reduce repeating messages (default off).
+$RepeatedMsgReduction on
+
+#### Modules ####
+
+module(load="imfile" PollingInterval="10")
+
+input(type="imfile"
+      File="/tmp/borgwarehouse.log"
+      Tag="BGINFO"
+      Severity="info"
+      Facility="local7")
+
+input(type="imfile"
+      File="/tmp/sshd.log"
+      Tag="SSHDINFO"
+      Severity="info"
+      Facility="local7")
+
+
+$template myFormat,"%timegenerated:::date-rfc3339% %syslogtag% %msg%\n"
+*.*    |/dev/stdout;myFormat

--- a/docker-resources/sshd_config
+++ b/docker-resources/sshd_config
@@ -1,0 +1,123 @@
+#       $OpenBSD: sshd_config,v 1.104 2021/07/02 05:11:21 dtucker Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# The strategy used for options in the default sshd_config shipped with
+# OpenSSH is to specify options with their default value where
+# possible, but leave them commented.  Uncommented options override the
+# default value.
+
+Port 2222
+#AddressFamily any
+ListenAddress 0.0.0.0
+#ListenAddress ::
+
+HostKey /etc_ssh/etc/ssh/ssh_host_rsa_key
+HostKey /etc_ssh/etc/ssh/ssh_host_ecdsa_key
+HostKey /etc_ssh/etc/ssh/ssh_host_ed25519_key
+
+# Ciphers and keying
+#RekeyLimit default none
+
+# Logging
+#SyslogFacility AUTH
+#LogLevel DEBUG
+
+# Authentication:
+
+#LoginGraceTime 2m
+#PermitRootLogin prohibit-password
+#######################
+# Important if you use nss_wrapper because
+# the real owner is 1001 and ssh refuse to start if directory structure is different
+# not recommended in multi-users environment but this container could run with only one user
+# and this is expected in this context
+StrictModes no
+########################
+#MaxAuthTries 6
+#MaxSessions 10
+
+#PubkeyAuthentication yes
+
+# The default is to check both .ssh/authorized_keys and .ssh/authorized_keys2
+# but this is overridden so installations will only check .ssh/authorized_keys
+AuthorizedKeysFile .ssh/authorized_keys
+
+#AuthorizedPrincipalsFile none
+
+#AuthorizedKeysCommand none
+#AuthorizedKeysCommandUser nobody
+
+# For this to work you will also need host keys in /etc/ssh/ssh_known_hosts
+#HostbasedAuthentication no
+# Change to yes if you don't trust ~/.ssh/known_hosts for
+# HostbasedAuthentication
+#IgnoreUserKnownHosts no
+# Don't read the user's ~/.rhosts and ~/.shosts files
+#IgnoreRhosts yes
+
+# To disable tunneled clear text passwords, change to no here!
+#PasswordAuthentication yes
+#PermitEmptyPasswords no
+
+# Change to no to disable s/key passwords
+#KbdInteractiveAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+#KerberosGetAFSToken no
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the KbdInteractiveAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via KbdInteractiveAuthentication may bypass
+# the setting of "PermitRootLogin prohibit-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and KbdInteractiveAuthentication to 'no'.
+#UsePAM no
+
+#AllowAgentForwarding yes
+# Feel free to re-enable these if your use case requires them.
+AllowTcpForwarding no
+GatewayPorts no
+X11Forwarding no
+#X11DisplayOffset 10
+#X11UseLocalhost yes
+#PermitTTY yes
+#PrintMotd yes
+#PrintLastLog yes
+#TCPKeepAlive yes
+#PermitUserEnvironment no
+#Compression delayed
+#ClientAliveInterval 0
+#ClientAliveCountMax 3
+#UseDNS no
+PidFile /etc_ssh/etc/ssh/sshd.pid
+#MaxStartups 10:30:100
+#PermitTunnel no
+#ChrootDirectory none
+#VersionAddendum none
+
+# no default banner path
+#Banner none
+
+# override default of no subsystems
+Subsystem sftp internal-sftp
+
+# Example of overriding settings on a per-user basis
+#Match User anoncvs
+#       X11Forwarding no
+#       AllowTcpForwarding no
+#       PermitTTY no
+#       ForceCommand cvs server

--- a/docker-resources/sshd_config
+++ b/docker-resources/sshd_config
@@ -15,16 +15,16 @@ Port 2222
 ListenAddress 0.0.0.0
 #ListenAddress ::
 
-HostKey /etc_ssh/etc/ssh/ssh_host_rsa_key
-HostKey /etc_ssh/etc/ssh/ssh_host_ecdsa_key
-HostKey /etc_ssh/etc/ssh/ssh_host_ed25519_key
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
 
 # Ciphers and keying
 #RekeyLimit default none
 
 # Logging
-#SyslogFacility AUTH
-#LogLevel DEBUG
+# SyslogFacility AUTH
+LogLevel INFO
 
 # Authentication:
 
@@ -60,7 +60,7 @@ AuthorizedKeysFile .ssh/authorized_keys
 #IgnoreRhosts yes
 
 # To disable tunneled clear text passwords, change to no here!
-#PasswordAuthentication yes
+PasswordAuthentication no
 #PermitEmptyPasswords no
 
 # Change to no to disable s/key passwords
@@ -103,7 +103,7 @@ X11Forwarding no
 #ClientAliveInterval 0
 #ClientAliveCountMax 3
 #UseDNS no
-PidFile /etc_ssh/etc/ssh/sshd.pid
+PidFile /tmp/sshd.pid
 #MaxStartups 10:30:100
 #PermitTunnel no
 #ChrootDirectory none

--- a/docker-resources/sshd_config
+++ b/docker-resources/sshd_config
@@ -113,7 +113,7 @@ PidFile /etc_ssh/etc/ssh/sshd.pid
 #Banner none
 
 # override default of no subsystems
-Subsystem sftp internal-sftp
+#Subsystem sftp internal-sftp
 
 # Example of overriding settings on a per-user basis
 #Match User anoncvs

--- a/docker-resources/supervisord.conf
+++ b/docker-resources/supervisord.conf
@@ -1,0 +1,30 @@
+[supervisord]
+nodaemon=true
+user = borgwarehouse
+logfile = /tmp/supervisord.log
+pidfile = /tmp/supervisord.pid
+logfile_maxbytes = 5MB
+logfile_backups=1
+loglevel=critical
+logformatter=%(asctime)s [%(levelname)s] %(message)s
+
+[program:sshd]
+command=/usr/sbin/sshd -D -e
+redirect_stderr=true
+stdout_logfile=/tmp/sshd.log
+stdout_logfile_maxbytes=5MB
+stdout_logfile_backups=1
+
+[program:borgwarehouse]
+command=/usr/local/bin/node server.js
+redirect_stderr=true
+stdout_logfile=/tmp/borgwarehouse.log
+stdout_logfile_maxbytes=5MB
+stdout_logfile_backups=1
+
+[program:rsyslogd]
+command=rsyslogd -n -i /tmp/rsyslogd.pid -f /etc/rsyslog.conf
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stdout_logfile_backups=0

--- a/docker/docker-bw-init.sh
+++ b/docker/docker-bw-init.sh
@@ -78,6 +78,4 @@ create_authorized_keys_file
 check_repos_directory
 get_SSH_fingerprints
 
-sudo service ssh restart
-
-exec "$@"
+exec supervisord -c /home/borgwarehouse/app/supervisord.conf

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,10 @@
+[supervisord]
+nodaemon=true
+logfile=/home/borgwarehouse/supervisord.log
+pidfile=/home/borgwarehouse/supervisord.pid
+
+[program:sshd]
+command=/usr/sbin/sshd -D
+
+[program:borgwarehouse]
+command=/usr/local/bin/node server.js

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -26,6 +26,8 @@ export const authOptions = {
                                 password:
                                     '$2a$12$20yqRnuaDBH6AE0EvIUcEOzqkuBtn1wDzJdw2Beg8w9S.vEqdso0a',
                                 roles: ['admin'],
+                                emailAlert: false,
+                                appriseAlert: false,
                             },
                         ])
                     );

--- a/pages/api/cronjob/checkStatus.js
+++ b/pages/api/cronjob/checkStatus.js
@@ -102,6 +102,7 @@ export default async function handler(req, res) {
             for (let index in newRepoList) {
                 if (
                     !newRepoList[index].status &&
+                    newRepoList[index].alert !== 0 &&
                     (!newRepoList[index].lastStatusAlertSend ||
                         date - newRepoList[index].lastStatusAlertSend > 90000)
                 ) {

--- a/pages/api/repo/add.js
+++ b/pages/api/repo/add.js
@@ -19,7 +19,7 @@ export default async function handler(req, res) {
         const { alias, sshPublicKey, size, comment, alert, lanCommand } =
             req.body;
         //We check that we receive data for each variable. Only "comment" and "lanCommand" are optional in the form.
-        if (!alias || !sshPublicKey || !size || !alert) {
+        if (!alias || !sshPublicKey || !size || (!alert && alert !== 0)) {
             //If a variable is empty.
             res.status(422).json({
                 message: 'Unexpected data',

--- a/pages/api/repo/id/[slug]/edit.js
+++ b/pages/api/repo/id/[slug]/edit.js
@@ -19,7 +19,7 @@ export default async function handler(req, res) {
         const { alias, sshPublicKey, size, comment, alert, lanCommand } =
             req.body;
         //We check that we receive data for each variable. Only "comment" and "lanCommand" are optional in the form.
-        if (!alias || !sshPublicKey || !size || !alert) {
+        if (!alias || !sshPublicKey || !size || (!alert && alert !== 0)) {
             //If a variable is empty.
             res.status(422).json({
                 message: 'Unexpected data',

--- a/pages/api/version/index.js
+++ b/pages/api/version/index.js
@@ -1,0 +1,16 @@
+import packageInfo from '../../../package.json';
+
+export default async function handler(req, res) {
+    if (req.method === 'GET') {
+        try {
+            res.status(200).json({ version: packageInfo.version });
+            return;
+        } catch (error) {
+            res.status(500).json({
+                status: 500,
+                message: 'API error, contact the administrator !',
+            });
+            return;
+        }
+    }
+}


### PR DESCRIPTION
closes #107 

speedup from 6+h (did not finish) down to less than 2 minutes on GitHub actions

- build the app using the host architecture (js is architecture-independent)
- install jc without the need to compile native dependencies
  - before this patch jc wasn't even functional due to missing dependencies that were not copied over from the jc build stage, installing the pre-compiled dependencies directly from Alpine first allows us to skip installing and building them when using pip to install jc. Installing jc directly in the final stage also avoids the previous problems with missing Python dependencies.
- fix a bug with host key generation
- add coreutils to fix the `stat` command
- add optional `DOCKERHUB_NAMESPACE` Github actions variable that allows people forking the project to run ci and push to their own account without the need to change ci files

things that I noticed are still broken on the develop branch:
- the `./docker` directory as well as the files within are unused
- the new entry point from `./docker-resources/entrypoint.sh` is missing a lot of things that were in the old entrypoint
  - authorized_keys creation
  - directory existence checks
  - ssh fingerprint env variables
  - CRONJOB_KEY and NEXTAUTH_SECRET checks and generation