### PR TITLE
fix: arm ci/cd build with node20

### DIFF
--- a/.github/workflows/docker-image-develop.yml
+++ b/.github/workflows/docker-image-develop.yml
@@ -25,5 +25,5 @@ jobs:
               with:
                   context: .
                   push: true
-                  platforms: linux/amd64,linux/arm64,linux/arm/v7
+                  platforms: linux/amd64,linux/arm64 # linux/arm/v7 arm32 is not supported by node20 https://github.com/nodejs/docker-node/issues/1946
                   tags: borgwarehouse/borgwarehouse:develop

--- a/.github/workflows/docker-image-latest.yml
+++ b/.github/workflows/docker-image-latest.yml
@@ -25,5 +25,5 @@ jobs:
               with:
                   context: .
                   push: true
-                  platforms: linux/amd64,linux/arm64,linux/arm/v7
+                  platforms: linux/amd64,linux/arm64 # linux/arm/v7 arm32 is not supported by node20 https://github.com/nodejs/docker-node/issues/1946
                   tags: borgwarehouse/borgwarehouse:latest

--- a/.github/workflows/docker-image-release.yml
+++ b/.github/workflows/docker-image-release.yml
@@ -28,5 +28,5 @@ jobs:
               with:
                   context: .
                   push: true
-                  platforms: linux/amd64,linux/arm64,linux/arm/v7
+                  platforms: linux/amd64,linux/arm64 # linux/arm/v7 arm32 is not supported by node20 https://github.com/nodejs/docker-node/issues/1946
                   tags: borgwarehouse/borgwarehouse:${{ steps.get_release_tag.outputs.TAG }}

--- a/.github/workflows/docker-image-test.yml
+++ b/.github/workflows/docker-image-test.yml
@@ -18,4 +18,4 @@ jobs:
               uses: docker/setup-buildx-action@v3
             - name: Build Docker Container
               run: |
-                  docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t borgwarehouse:pr-${{ github.event.pull_request.number }} .
+                  docker buildx build --platform linux/amd64,linux/arm64 -t borgwarehouse:pr-${{ github.event.pull_request.number }} .


### PR DESCRIPTION
# linux/arm/v7 arm32 is not supported by node20 https://github.com/nodejs/docker-node/issues/1946