### PR TITLE
Added check if GID already exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install -y \
     supervisor curl jq jc borgbackup/bookworm-backports openssh-server rsyslog && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN groupadd -g ${GID} borgwarehouse && useradd -m -u ${UID} -g ${GID} borgwarehouse
+RUN if ! getent group ${GID} ; then groupadd -g ${GID} borgwarehouse; fi && useradd -m -u ${UID} -g ${GID} borgwarehouse
 
 RUN cp /etc/ssh/moduli /home/borgwarehouse/
 


### PR DESCRIPTION
I wanted to use borgwarehouse with group-id 100. But the build process failed because a group with that id already exist. therefore I added a small if clause to check if a group with that id already exists. 