### PR TITLE
Make ARGs compliant with Docker specs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:20-bookworm-slim as base
-
 ARG UID=1001
 ARG GID=1001
+
+FROM node:20-bookworm-slim as base
 
 # build stage
 FROM base AS deps
@@ -26,6 +26,9 @@ RUN npm run build
 
 # run stage
 FROM base AS runner
+
+ARG UID
+ARG GID
 
 ENV NODE_ENV production
 


### PR DESCRIPTION
The arguments  UID and GID were declared in the first FROM part of the Docker image, which made them non-compliant with the Docker specs. This resulted in a failed build, if the build was done without docker-compose:

```
RUN groupadd -g ${GID} borgwarehouse && useradd -m -u ${UID} -g ${GID} borgwarehouse
groupadd: invalid group ID 'borgwarehouse'
```

https://docs.docker.com/reference/dockerfile/#understand-how-arg-and-from-interact

