### PR TITLE
Feature/repo refresh option

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -39,3 +39,6 @@ MAIL_SMTP_PORT=
 MAIL_SMTP_LOGIN=
 MAIL_SMTP_PWD=
 MAIL_REJECT_SELFSIGNED_TLS=
+
+# Misc
+AUTO_REFRESH=false # Set to "true" if you want to refresh the UI Metadata after any borg serve finished

--- a/docker/docker-bw-init.sh
+++ b/docker/docker-bw-init.sh
@@ -75,12 +75,26 @@ check_env() {
   fi
 }
 
+check_auto_refresh() {
+  if [ -z "$AUTO_REFRESH" ]; then
+    AUTO_REFRESH="false"
+    export AUTO_REFRESH
+  fi
+
+  if [ "$AUTO_REFRESH" = "true" ]; then
+    sed -ri "/command=\".*${repositoryName}.*\",restrict/ {/\;\/bin\/bash \/home\/borgwarehouse\/app\/helpers\/shells\/cronjob\.sh\",restrict/! s/\",restrict/;\/bin\/bash \/home\/borgwarehouse\/app\/helpers\/shells\/cronjob\.sh\",restrict/}" "$AUTHORIZED_KEYS_FILE"
+  else
+    sed -ri "/command=\".*${repositoryName}.*\",restrict/ s/;\/bin\/bash \/home\/borgwarehouse\/app\/helpers\/shells\/cronjob.sh//g" "$AUTHORIZED_KEYS_FILE"
+  fi
+}
+
 check_env
 init_ssh_server
 check_ssh_directory
 create_authorized_keys_file
 check_repos_directory
 get_SSH_fingerprints
+check_auto_refresh
 
 print_green "Successful initialization. BorgWarehouse is ready !"
 exec supervisord -c /home/borgwarehouse/app/supervisord.conf 

--- a/helpers/shells/createRepo.sh
+++ b/helpers/shells/createRepo.sh
@@ -76,8 +76,15 @@ else
     appendOnlyMode=""
 fi
 
+# Refresh Mode
+if [ "$AUTO_REFRESH" == "true" ]; then
+    autoRefresh=";/bin/bash /home/borgwarehouse/app/helpers/shells/cronjob.sh"
+else
+    autoRefresh=""
+fi
+
 ## Add ssh public key in authorized_keys with borg restriction for only 1 repository and storage quota
-restricted_authkeys="command=\"cd ${pool};borg serve${appendOnlyMode} --restrict-to-path ${pool}/${repositoryName} --storage-quota $2G\",restrict $1"
+restricted_authkeys="command=\"cd ${pool};borg serve${appendOnlyMode} --restrict-to-path ${pool}/${repositoryName} --storage-quota $2G${autoRefresh}\",restrict $1"
 echo "$restricted_authkeys" | tee -a "${authorized_keys}" >/dev/null
 
 ## Return the repositoryName

--- a/helpers/shells/cronjob.sh
+++ b/helpers/shells/cronjob.sh
@@ -1,0 +1,9 @@
+#!/bin/bash bash
+
+# This shell can be called to execute all cronjobs to refresh the instance
+# This may be enabled as a setting to refresh the storage used after any borg serve command finishes
+
+source /home/borgwarehouse/app/.env
+
+curl --request POST --url "${NEXTAUTH_URL}/api/cronjob/checkStatus" --header "Authorization: Bearer ${CRONJOB_KEY}"
+curl --request POST --url "${NEXTAUTH_URL}/api/cronjob/getStorageUsed" --header "Authorization: Bearer ${CRONJOB_KEY}"


### PR DESCRIPTION
Hi,

coming from https://github.com/Ravinou/borgwarehouse/issues/247#issuecomment-2195580701

I implemented an environmental variable that enables / disables (by default) an `AUTO_REFRESH` option.
If this option is enabled, each ssh forced commands get appended a script to call the warehouse api to fetch the latest details about the repo.

This approach is better than any cronjob since it get's executed only if a borg activity has happened (not just on a timely basis).

I hope this get pulled since i expect this to be a useful feature for others also. 