### PR TITLE
fix: listen on all interfaced in Docker

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -14,6 +14,7 @@ stdout_logfile_backups=5
 redirect_stderr=true
 
 [program:borgwarehouse]
+environment=HOSTNAME=0.0.0.0
 command=/usr/local/bin/node server.js
 stdout_logfile=/home/borgwarehouse/tmp/borgwarehouse.log
 stdout_logfile_maxbytes=10MB


### PR DESCRIPTION
By default, the `HOSTNAME` environment variable will have the container's hostname. NodeJS `server.listen` when used with a hostname that resolved to multiple addresses will only use the first one. By setting it to 0.0.0.0 we are restoring the default behavior of Next.js and listening on all interfaces.

fixes #285

Edit: not sure if stating it like this allows the user to overwrite it