### PR TITLE
Add voumes to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,22 @@ COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/docker/supervisord.
 COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/docker/rsyslog.conf /etc/rsyslog.conf
 COPY --from=builder --chown=borgwarehouse:borgwarehouse /app/docker/sshd_config ./
 
+RUN chown -R borgwarehouse:borgwarehouse /etc/ssh
+
 USER borgwarehouse
+
+RUN mkdir -p /home/borgwarehouse/app/config \
+    /home/borgwarehouse/.ssh \
+    /home/borgwarehouse/repos \
+    /home/borgwarehouse/tmp \
+    /home/borgwarehouse/logs
+
+VOLUME /home/borgwarehouse/app/config \
+       /home/borgwarehouse/.ssh \
+       /etc/ssh \
+       /home/borgwarehouse/repos \
+       /home/borgwarehouse/tmp \
+       /home/borgwarehouse/logs
 
 EXPOSE 3000 22
 


### PR DESCRIPTION
Docker recommends to mount volumes instead of mounting directories. This is currently not supported by Borgwarehouse. This is due to some ownership issues. This can be solved by a small change in the Dockerfile.

For example:
```yaml
...
    volumes:
      - config:/home/borgwarehouse/app/config
      - user-ssh:/home/borgwarehouse/.ssh
      - etc-ssh:/etc/ssh
      - repos:/home/borgwarehouse/repos
      - tmp:/home/borgwarehouse/tmp
      - logs:/home/borgwarehouse/logs

volumes:
  config:
  user-ssh:
  etc-ssh:
  repos:
  tmp:
  logs:
```