### PR TITLE
fix: remove hardcoded HOSTNAME in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ARG UID
 ARG GID
 
 ENV NODE_ENV production
+ENV HOSTNAME=
 
 RUN echo 'deb http://deb.debian.org/debian bookworm-backports main' >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y \

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -14,7 +14,6 @@ stdout_logfile_backups=5
 redirect_stderr=true
 
 [program:borgwarehouse]
-environment=HOSTNAME=0.0.0.0
 command=/usr/local/bin/node server.js
 stdout_logfile=/home/borgwarehouse/tmp/borgwarehouse.log
 stdout_logfile_maxbytes=10MB


### PR DESCRIPTION
Instead of hardcoding it in supervisord.conf, we simply set it to an empty value in the Dockerfile. This prevents docker from setting it's own value while also allowing the user to override it.

In next JS an empty HOSTNAME is equivalent to not setting it at all.

fixes #285