### PR TITLE
Changed "last changes" to a more human-readable format

### DIFF
--- a/Components/Repo/Repo.tsx
+++ b/Components/Repo/Repo.tsx
@@ -11,7 +11,7 @@ import {
 import StorageBar from '../UI/StorageBar/StorageBar';
 import QuickCommands from './QuickCommands/QuickCommands';
 import { Repository, WizardEnvType, Optional } from '~/types';
-import { fromUnixTime } from 'date-fns';
+import { fromUnixTime, formatDistanceStrict } from 'date-fns';
 
 type RepoProps = Omit<Repository, 'unixUser' | 'displayDetails'> & {
   repoManageEditHandler: () => void;
@@ -123,8 +123,19 @@ export default function Repo(props: RepoProps) {
                     <StorageBar storageUsed={props.storageUsed} storageSize={props.storageSize} />
                   </th>
                   <th>
-                    <div className={classes.lastSave}>
-                      {props.lastSave === 0 ? '-' : fromUnixTime(props.lastSave).toLocaleString()}
+                    <div
+                      className={classes.lastSave}
+                      title={
+                        props.lastSave === 0
+                          ? undefined
+                          : fromUnixTime(props.lastSave).toLocaleString()
+                      }
+                    >
+                      {props.lastSave === 0
+                        ? '-'
+                        : formatDistanceStrict(fromUnixTime(props.lastSave), Date.now(), {
+                            addSuffix: true,
+                          })}
                     </div>
                   </th>
                   <th>#{props.id}</th>
@@ -158,7 +169,17 @@ export default function Repo(props: RepoProps) {
               )}
             </div>
             <div className={classes.lastSave}>
-              {props.lastSave === 0 ? null : fromUnixTime(props.lastSave).toLocaleString()}
+              <span
+                title={
+                  props.lastSave === 0 ? undefined : fromUnixTime(props.lastSave).toLocaleString()
+                }
+              >
+                {props.lastSave === 0
+                  ? '-'
+                  : formatDistanceStrict(fromUnixTime(props.lastSave), Date.now(), {
+                      addSuffix: true,
+                    })}
+              </span>
               <span style={{ marginLeft: '20px', color: '#637381' }}>#{props.id}</span>
             </div>
           </div>


### PR DESCRIPTION
This PR makes it a lot easier to read when the last change was

This changes the "last change" timestamp from a fixed date to a relative time (e.g. `30 seconds ago`, `two days ago` or `one month ago`). The full timestamp is moved to the title of the div and will be shown on mouse hover.