### PR TITLE
Add feature that disallows reverting append-only mode

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -35,6 +35,9 @@ SSH_SERVER_PORT_LAN=
 # Disable the DELETE feature
 #DISABLE_DELETE_REPO=true
 
+# Do not allow to remove append-only mode, once set
+#DISABLE_REVERT_APPEND_ONLY=true
+
 # Disable the integrations (API tokens to CRUD repositories)
 #DISABLE_INTEGRATIONS=true
 

--- a/Containers/RepoManage/RepoManage.tsx
+++ b/Containers/RepoManage/RepoManage.tsx
@@ -221,10 +221,18 @@ export default function RepoManage(props: RepoManageProps) {
             );
             router.replace('/');
           } else {
-            const errorMessage = await response.json();
-            toast.error(`An error has occurred : ${errorMessage.message.stderr}`, toastOptions);
-            router.replace('/');
-            console.log(`Fail to ${props.mode}`);
+            if (response.status == 403) {
+              toast.warning(
+                '🔒 The server is currently protected against reverting append-only mode.',
+                toastOptions
+              );
+              router.replace('/');
+            } else {
+              const errorMessage = await response.json();
+              toast.error(`An error has occurred : ${errorMessage.message.stderr}`, toastOptions);
+              router.replace('/');
+              console.log(`Fail to ${props.mode}`);
+            }
           }
         })
         .catch((error) => {

--- a/pages/api/v1/repositories/[slug]/index.ts
+++ b/pages/api/v1/repositories/[slug]/index.ts
@@ -94,6 +94,15 @@ export default async function handler(
             'The SSH key is already used in another repository. Please use another key or delete the key from the other repository.',
         });
       }
+      if (repo.appendOnlyMode && appendOnlyMode === false) {
+	  if (process.env.DISABLE_REVERT_APPEND_ONLY === "true") {
+	    res.status(403).json({
+	    status: 403,
+	    message: 'Reverting Append-Only mode is disabled on this server',
+	    });
+	  return;
+	}
+      }
 
       const updatedRepo: Repository = {
         ...repo,


### PR DESCRIPTION
This PR adds a feature that disables reverting back from append-only mode to normal mode. It is off by default.

This can be used for additional security. For example, if the repo is append-only, an attacker with access to an API key with `update` permission (or the web UI  if `DISABLE_DELETE_REPO` is set) and backup source should not be able to delete the repo.
However, by removing the append-only mode, uploading an empty backup, deleting all previous backups and compacting the repo, the attacker deleted all data and leaves an empty repository. This feature would prevent this (most likely rather remote) case.