### PR TITLE
Add API endpoint and UI button to compact repo

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -35,6 +35,9 @@ SSH_SERVER_PORT_LAN=
 # Disable the DELETE feature
 #DISABLE_DELETE_REPO=true
 
+# Do not allow to compact append-only repos from UI or API
+#DISABLE_COMPACT_APPEND_ONLY=true
+
 # Disable the integrations (API tokens to CRUD repositories)
 #DISABLE_INTEGRATIONS=true
 

--- a/Components/Repo/Repo.tsx
+++ b/Components/Repo/Repo.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import classes from './Repo.module.css';
 import {
-  IconSettings,
+  IconPencil,
+  IconArrowsMinimize,
   IconInfoCircle,
   IconChevronDown,
   IconChevronUp,
@@ -15,6 +16,7 @@ import { fromUnixTime } from 'date-fns';
 
 type RepoProps = Omit<Repository, 'unixUser' | 'displayDetails'> & {
   repoManageEditHandler: () => void;
+  repoManageCompactHandler: () => void;
   wizardEnv: Optional<WizardEnvType>;
 };
 
@@ -130,10 +132,17 @@ export default function Repo(props: RepoProps) {
                   <th>#{props.id}</th>
                   <th>
                     <div className={classes.editButton}>
-                      <IconSettings
+                      <IconPencil
+                        title="Edit repository"
                         width={24}
                         color='#6d4aff'
                         onClick={() => props.repoManageEditHandler()}
+                      />
+                      <IconArrowsMinimize
+                        title="Compact repository"
+                        width={24}
+                        color='#6d4aff'
+                        onClick={() => props.repoManageCompactHandler()}
                       />
                     </div>
                   </th>

--- a/Containers/RepoList/RepoList.tsx
+++ b/Containers/RepoList/RepoList.tsx
@@ -93,6 +93,37 @@ export default function RepoList() {
     router.replace('/manage-repo/edit/' + id);
   };
 
+  //BUTTON : Start compacting
+  const manageRepoCompactHandler = async (name: string) => {
+    await fetch('/api/v1/repositories/' + name + '/compact', {
+    method: 'POST',
+    headers: {
+      'Content-type': 'application/json',
+    }})
+    .then(async (response) => {
+      if (response.ok) {
+        toast.success(
+          'Compacting repository ' + name + '. This might take a while.',
+          toastOptions
+        );
+      } else {
+        if (response.status == 403) {
+          toast.warning(
+            '🔒 The server is currently protected against compaction on append-only repositories.',
+            toastOptions
+          );
+          return;
+        }
+        const errorMessage = await response.json();
+        toast.error(`An error has occurred : ${errorMessage.message.stderr}`, toastOptions);
+      }
+    })
+    .catch((error) => {
+      toast.error('An error has occurred', toastOptions);
+      console.log(error);
+    })
+  };
+
   //BUTTON : Close RepoManage component box (when cross is clicked)
   const closeRepoManageBoxHandler = () => {
     router.replace('/');
@@ -126,6 +157,9 @@ export default function RepoList() {
           lanCommand={repo.lanCommand}
           appendOnlyMode={repo.appendOnlyMode}
           repoManageEditHandler={() => manageRepoEditHandler(repo.id)}
+          repoManageCompactHandler={async () => {
+            await manageRepoCompactHandler(repo.repositoryName);
+          }}
           wizardEnv={wizardEnv}
         ></Repo>
       </React.Fragment>

--- a/helpers/shells/compactRepo.sh
+++ b/helpers/shells/compactRepo.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Shell created by Forceu for BorgWarehouse.
+# This shell takes 1 arg : [repositoryName] with 8 char. length only.
+# This shell compacts the repository in arg.
+
+# Exit when any command fails
+set -e
+
+# Load .env if exists
+if [[ -f .env ]]; then
+    source .env
+fi
+
+# Default value if .env not exists
+: "${home:=/home/borgwarehouse}"
+
+# Some variables
+pool="${home}/repos"
+
+# Check arg
+if [[ $# -ne 1 || $1 = "" ]]; then
+    echo -n "You must provide a repositoryName in argument." >&2
+    exit 1
+fi
+
+# Check if the repositoryName pattern is an hexa 8 char. With createRepo.sh our randoms are hexa of 8 characters.
+# If we receive another pattern there is necessarily a problem.
+repositoryName=$1
+if ! [[ "$repositoryName" =~ ^[a-f0-9]{8}$ ]]; then
+  echo "Invalid repository name. Must be an 8-character hex string." >&2
+  exit 2
+fi
+
+
+# Check if borgbackup is installed
+if ! [ -x "$(command -v borg)" ]; then
+  echo -n "You must install borgbackup package." >&2
+  exit 3
+fi
+
+# Compact the repository
+if [ -d "${pool}/${repositoryName}" ]; then
+  # Compacting
+  borg compact "${pool}"/"${repositoryName}"
+  echo -n "Compacting of ""${repositoryName}"" complete"
+else
+  echo "Repository path does not exist" >&2
+  exit 4
+fi

--- a/pages/api/v1/repositories/[slug]/compact/index.test.ts
+++ b/pages/api/v1/repositories/[slug]/compact/index.test.ts
@@ -1,0 +1,136 @@
+import { createMocks } from 'node-mocks-http';
+import handler from '~/pages/api/v1/repositories/[slug]/compact';
+import { getServerSession } from 'next-auth/next';
+import { ConfigService, AuthService, ShellService } from '~/services';
+
+
+
+vi.mock('next-auth/next', () => ({
+  getServerSession: vi.fn(),
+}));
+vi.mock('~/services');
+
+
+const mockRepoList = [
+  { repositoryName: 'abcdef12', appendOnlyMode: false },
+  { repositoryName: '12345678', appendOnlyMode: true },
+];
+
+describe('/api/v1/repositories/[slug] handler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(ConfigService.getRepoList).mockResolvedValue([...mockRepoList]);
+    vi.mocked(ConfigService.updateRepoList).mockResolvedValue(undefined);
+    vi.mocked(ShellService.getStorageUsed).mockResolvedValue([]);
+    vi.mocked(ShellService.compactRepo).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('should return 401 if no session or authorization header is provided', async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    const { req, res } = createMocks({ method: 'POST', query: { slug: 'abcdef12' } });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(401);
+  });
+
+  it('should return 400 for invalid slug', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: {} });
+    const { req, res } = createMocks({ method: 'POST', query: { slug: 'nothex' } });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getData()).toContain('valid repository name');
+  });
+
+  it('should return 404 if repository is not found', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: {} });
+    vi.mocked(ConfigService.getRepoList).mockResolvedValue([]);
+    const { req, res } = createMocks({ method: 'POST', query: { slug: '45678912' } });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getData()).toContain('No repository with name');
+  });
+
+  it('should return 403 if repo is append-only and env disables compacting', async () => {
+    process.env.DISABLE_COMPACT_APPEND_ONLY = 'true';
+    vi.mocked(getServerSession).mockResolvedValue({ user: {} });
+    const { req, res } = createMocks({ method: 'POST', query: { slug: '12345678' } });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getData()).toContain('does not allow compacting');
+  });
+
+  it('should return 400 if await is not a boolean', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: {} });
+    const { req, res } = createMocks({
+      method: 'POST',
+      query: { slug: 'abcdef12' },
+      body: { await: 'yes' },
+    });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getData()).toContain('await must be a boolean');
+  });
+
+  it('should start compaction if await is false', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: {} });
+    const { req, res } = createMocks({
+      method: 'POST',
+      query: { slug: 'abcdef12' },
+      body: { await: false },
+    });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData()).toContain('has started compaction');
+    expect(ShellService.compactRepo).toHaveBeenCalledWith('abcdef12');
+  });
+
+  it('should await compaction if await is true', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: {} });
+    const { req, res } = createMocks({
+      method: 'POST',
+      query: { slug: 'abcdef12' },
+      body: { await: true },
+    });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getData()).toContain('has been compacted');
+    expect(ShellService.compactRepo).toHaveBeenCalledWith('abcdef12');
+    expect(ConfigService.updateRepoList).toHaveBeenCalled();
+  });
+
+  it('should return 403 if API token is valid but lacks permission', async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(AuthService.tokenController).mockResolvedValue({ update: false });
+    const { req, res } = createMocks({
+      method: 'POST',
+      query: { slug: 'abcdef12' },
+      headers: { authorization: 'Bearer something' },
+    });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getData()).toContain('Insufficient permissions');
+  });
+
+  it('should return 401 if API token is invalid', async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    vi.mocked(AuthService.tokenController).mockResolvedValue(null);
+    const { req, res } = createMocks({
+      method: 'POST',
+      query: { slug: 'abcdef12' },
+      headers: { authorization: 'Bearer invalid' },
+    });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(401);
+    expect(res._getData()).toContain('Invalid API key');
+  });
+
+  it('should return 405 if method is not POST', async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: {} });
+    const { req, res } = createMocks({ method: 'GET', query: { slug: 'abcdef12' } });
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(405);
+  });
+});

--- a/pages/api/v1/repositories/[slug]/compact/index.ts
+++ b/pages/api/v1/repositories/[slug]/compact/index.ts
@@ -1,0 +1,90 @@
+import { authOptions } from '~/pages/api/auth/[...nextauth]';
+import { getServerSession } from 'next-auth/next';
+import { NextApiRequest, NextApiResponse } from 'next';
+import { BorgWarehouseApiResponse, Repository } from '~/types';
+import ApiResponse from '~/helpers/functions/apiResponse';
+import { ConfigService, AuthService, ShellService } from '~/services';
+import repositoryNameCheck from '~/helpers/functions/repositoryNameCheck';
+
+
+const updateStorage = async () => {
+  const storageUsed = await ShellService.getStorageUsed();
+  const repoList = await ConfigService.getRepoList();
+
+  //Update the storageUsed value of each repository
+  const updatedRepoList = repoList.map((repo) => {
+    const repoFiltered = storageUsed.find((x) => x.name === repo.repositoryName);
+    if (!repoFiltered) return repo;
+    return {
+      ...repo,
+      storageUsed: repoFiltered.size,
+    };
+  });
+
+ await ConfigService.updateRepoList(updatedRepoList);
+};
+
+
+export default async function handler(
+  req: NextApiRequest & { body: Partial<Repository> },
+  res: NextApiResponse<BorgWarehouseApiResponse | { repo: Repository }>
+) {
+  const session = await getServerSession(req, res, authOptions);
+  const { authorization } = req.headers;
+  if (!session && !authorization) {
+    return ApiResponse.unauthorized(res);
+  }
+
+  // Validate slug
+  const slug = Array.isArray(req.query.slug) ? req.query.slug[0] : req.query.slug;
+  if (!slug || !repositoryNameCheck(slug)) {
+    return ApiResponse.badRequest(
+      res,
+      'Slug must be a valid repository name (8-character hexadecimal string)'
+    );
+  }
+
+  if (req.method == 'POST') {
+    try {
+      if (!session && authorization) {
+        const permissions = await AuthService.tokenController(req.headers);
+        if (!permissions) {
+          return ApiResponse.unauthorized(res, 'Invalid API key');
+        }
+        if (!permissions.update) {
+          return ApiResponse.forbidden(res, 'Insufficient permissions');
+        }
+      }
+    } catch (error) {
+      return ApiResponse.serverError(res, error);
+    }
+
+    try {
+      const repoList = await ConfigService.getRepoList();
+
+      const repo = repoList.find((repo) => repo.repositoryName === slug);
+      if (!repo) {
+        return ApiResponse.notFound(res, 'No repository with name ' + slug);
+      }
+      
+      if (repo.appendOnlyMode && process.env.DISABLE_COMPACT_APPEND_ONLY === 'true') {
+        return res.status(403).json({ status: 403, message: `Repository ${slug} is append-only and the server does not allow compacting` });
+      }
+
+      if (req.body.await !== undefined && typeof req.body.await !== 'boolean') {
+       throw new Error('await must be a boolean');
+      }
+      if (req.body.await) {
+        await ShellService.compactRepo(slug);
+        await updateStorage();
+        return res.status(200).json({ status: 200, message: `Repository ${slug} has been compacted` });
+      }
+      ShellService.compactRepo(slug);
+      return res.status(200).json({ status: 200, message: `Repository ${slug} has started compaction` });
+    } catch (error) {
+      return ApiResponse.serverError(res, error);
+    }
+  } 
+    return ApiResponse.methodNotAllowed(res);
+}
+

--- a/pages/api/v1/repositories/[slug]/compact/index.ts
+++ b/pages/api/v1/repositories/[slug]/compact/index.ts
@@ -64,7 +64,7 @@ export default async function handler(
 
       const repo = repoList.find((repo) => repo.repositoryName === slug);
       if (!repo) {
-        return ApiResponse.notFound(res, 'No repository with name ' + slug);
+        return res.status(404).json({ status: 404, message: `No repository with name ${slug}`});
       }
       
       if (repo.appendOnlyMode && process.env.DISABLE_COMPACT_APPEND_ONLY === 'true') {
@@ -72,7 +72,7 @@ export default async function handler(
       }
 
       if (req.body.await !== undefined && typeof req.body.await !== 'boolean') {
-       throw new Error('await must be a boolean');
+        return res.status(400).json({ status: 400, message: `await must be a boolean` });
       }
       if (req.body.await) {
         await ShellService.compactRepo(slug);

--- a/services/shell.service.ts
+++ b/services/shell.service.ts
@@ -44,6 +44,11 @@ export const ShellService = {
     const { stdout, stderr } = await exec(`${shellsDirectory}/deleteRepo.sh ${repositoryName}`);
     return { stdout, stderr };
   },
+  
+  compactRepo: async (repositoryName: string) => {
+    const { stdout, stderr } = await exec(`${shellsDirectory}/compactRepo.sh ${repositoryName}`);
+    return { stdout, stderr };
+  },
 
   updateRepo: async (
     repositoryName: string,

--- a/tests/README
+++ b/tests/README
@@ -1,3 +1,5 @@
 ## BATS tests against bash scripts
 
 From `tests/bats`, launch `docker compose up --build`
+
+If using Podman, you can use the command `podman build -t bats -f ./bats/Dockerfile ../.` and then `podman run --rm bats`

--- a/tests/bats/Dockerfile
+++ b/tests/bats/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add --no-cache \
     coreutils 
 
 COPY helpers/shells/ /test/scripts/
+COPY tests/bats/compactRepo.bats /test/tests/compactRepo.bats
 COPY tests/bats/createRepo.bats /test/tests/createRepo.bats
 COPY tests/bats/deleteRepo.bats /test/tests/deleteRepo.bats
 COPY tests/bats/updateRepo.bats /test/tests/updateRepo.bats

--- a/tests/bats/compactRepo.bats
+++ b/tests/bats/compactRepo.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+setup() {
+  export home="/tmp/borgwarehouse"
+  export BORG_REPO=""
+  mkdir -p "${home}/repos"
+
+  # Ensure borg is installed
+  if ! command -v borg >/dev/null; then
+    echo "borg not found in PATH; tests require borgbackup installed." >&2
+    exit 1
+  fi
+}
+
+teardown() {
+  rm -rf "${home}"
+}
+
+@test "Test compactRepo.sh with missing argument" {
+  run bash /test/scripts/compactRepo.sh
+  [ "$status" -eq 1 ]
+  [ "$output" = "You must provide a repositoryName in argument." ]
+}
+
+@test "Test compactRepo.sh with empty argument" {
+  run bash /test/scripts/compactRepo.sh ""
+  [ "$status" -eq 1 ]
+  [ "$output" = "You must provide a repositoryName in argument." ]
+}
+
+@test "Test compactRepo.sh with invalid repo name" {
+  run bash /test/scripts/compactRepo.sh "invalid"
+  [ "$status" -eq 2 ]
+  [ "$output" = "Invalid repository name. Must be an 8-character hex string." ]
+}
+
+@test "Test compactRepo.sh with missing repo path" {
+  run bash /test/scripts/compactRepo.sh "12345678"
+  [ "$status" -eq 4 ]
+  [ "$output" = "Repository path does not exist" ]
+}
+
+@test "Test compactRepo.sh with missing borg binary" {
+  mv "$(command -v borg)" /tmp/borg-real
+  run bash /test/scripts/compactRepo.sh "12345678"
+  [ "$status" -eq 3 ]
+  [ "$output" = "You must install borgbackup package." ]
+  mv /tmp/borg-real "$(dirname "$(command -v bash)")/borg"
+}
+
+@test "Test compactRepo.sh with sucessful compactation" {
+  repo_name="12345678"
+  repo_path="${home}/repos/${repo_name}"
+  backup_path="${home}/backup/testdata"
+  mkdir -p "$repo_path"
+  mkdir -p "$backup_path"
+  
+  dd if=/dev/random of="$backup_path/bigfile" bs=20M count=1
+
+  borg init --encryption=none "$repo_path"
+  borg create "$repo_path"::test "$backup_path"
+
+
+  # Get size before compaction (in bytes)
+  size_before=$(du -sb "$repo_path" | awk '{print $1}')
+  
+  # Run the compaction script
+  run bash /test/scripts/compactRepo.sh "$repo_name"
+  [ "$status" -eq 0 ]
+  [ "$output" = "Compacting of 12345678 complete" ]
+
+  # Get size after compaction
+  size_after=$(du -sb "$repo_path" | awk '{print $1}')
+
+  # Check that the size after is less than the size before
+  [[ "$size_after" -lt "$size_before" ]]
+}


### PR DESCRIPTION
This PR adds a button and an API endpoint to compact a repo and will close #222

The new api endpoint is `POST /api/v1/repositories/[id]/compact`. By default the call only initiates compacting and returns 200, if the parameter `await` is set to `true`, it will only return after compacting and an additional storage calculation is done.

Compacting can be disabled on append-only repos with the env `DISABLE_COMPACT_APPEND_ONLY`.

One drawback with compacting is however, that after the process is finished, it registers as a change. This means, a notification might not be send, if a future backup is not made and the notification period was exceeded. I think it is the same with borgbase and there is not really a way around it (other than saving the last date before compacting).

No tests or documentation were created / altered in this PR.