### PR TITLE
Clear default SSH server configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,9 @@ RUN apt-get update && apt-get install -y \
 
 RUN groupadd -g ${GID} borgwarehouse && useradd -m -u ${UID} -g ${GID} borgwarehouse
 
-RUN cp /etc/ssh/moduli /home/borgwarehouse/
+RUN rm -fr /etc/ssh/*
+# Unconfigure SSH so that we regenerate configuration at first launch
+# of the container.
 
 WORKDIR /home/borgwarehouse/app
 

--- a/docker/docker-bw-init.sh
+++ b/docker/docker-bw-init.sh
@@ -17,7 +17,8 @@ init_ssh_server() {
   if [ -z "$(ls -A /etc/ssh)" ]; then
     print_green "/etc/ssh is empty, generating SSH host keys..."
     ssh-keygen -A
-    cp /home/borgwarehouse/moduli /etc/ssh/
+    touch /etc/ssh/moduli
+    # Ignored by configuration
   fi
   if [ ! -f "/etc/ssh/sshd_config" ]; then
     print_green "sshd_config not found in your volume, copying the default one..."

--- a/docker/sshd_config
+++ b/docker/sshd_config
@@ -26,6 +26,10 @@ PermitTTY no
 Ciphers aes256-ctr,aes192-ctr,aes128-ctr
 MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com
 
+# Key exchange
+KexAlgorithms curve25519-sha256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256
+# Sidestep the need for RSA moduli by relying exclusively on ECDH
+
 # With low bandwidth or huge backup, uncomment the following lines to avoid SSH timeout (Broken pipe).
 #ClientAliveInterval 600 
 #ClientAliveCountMax 0


### PR DESCRIPTION
Remove the default sshd_config and the host keys generated whebn the openssh-server was installed, so that these do not end up on containers when starting with an empty volume for /etc/ssh (otherwise contents from the image will prime the empty container). This ensures that each new deployment will generate its own keys.

Also remove moduli and exclude legacy key exchange algorithms relying on them.