### PR TITLE
Change supervisord pid file path

### DIFF
--- a/docker/docker-bw-init.sh
+++ b/docker/docker-bw-init.sh
@@ -83,4 +83,5 @@ check_repos_directory
 get_SSH_fingerprints
 
 print_green "Successful initialization. BorgWarehouse is ready !"
-exec supervisord -c /home/borgwarehouse/app/supervisord.conf 
+rm -f /home/borgwarehouse/tmp/supervisord.pid
+exec supervisord -c /home/borgwarehouse/app/supervisord.conf

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -3,6 +3,7 @@ nodaemon=true
 logfile=/dev/stdout
 logfile_maxbytes=0
 loglevel=error
+pidfile=/home/borgwarehouse/tmp/supervisord.pid
 
 [program:sshd]
 command=/usr/sbin/sshd -D -e -f /etc/ssh/sshd_config


### PR DESCRIPTION
Use a path writable by user 1001.
Make sure that the pid file is cleared at container startup, before launching supervisord.