### PR TITLE
s/onlyBuiltDepndencies/allowBuilds/ in pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,5 +3,8 @@ packages:
 
 # better-sqlite3 is a native Node.js module (C++ binding) that requires
 # compilation at install time. This explicitly allows its build script to run.
-onlyBuiltDependencies:
-  - better-sqlite3
+allowBuilds:
+  better-sqlite3: true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
See https://pnpm.io/settings#allowbuilds for explanation of this pnpm 10 to pnpm 11 version change

I had to add all four packages to make it compile, not just better-sqlite3