### PR TITLE
Avoid creating the auth database during tests

### DIFF
--- a/helpers/__mocks__/getServerSession.ts
+++ b/helpers/__mocks__/getServerSession.ts
@@ -1,0 +1,3 @@
+import { vi } from 'vitest';
+
+export const getSession = vi.fn();


### PR DESCRIPTION
## What changed

Add a manual Vitest mock for `getServerSession`.

## Problem

The previous automatic mock still loaded the real module, which imported the auth setup and created `config/better_auth.sqlite` during tests.

## Why this helps

The manual mock avoids loading the production auth module, so tests no longer mutate the local application state.